### PR TITLE
Fix Rakefile when Jeweler is not installed

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,8 +1,9 @@
 $:.unshift File.expand_path('../lib', __FILE__)
 
+require 'log_buddy/version'
+
 begin
   require 'jeweler'
-  require 'log_buddy/version'
   Jeweler::Tasks.new do |gem|
     gem.name = "log_buddy"
     gem.version = LogBuddy::Version::STRING


### PR DESCRIPTION
The LogBuddy::VERSION constant is used by the RDoc task as well, so make
sure to require it in top-level, as the Rakefile won't work otherwise.
