### PR TITLE
Added ability to wrap output in a banner to make it easier to find

### DIFF
--- a/.rvmrc
+++ b/.rvmrc
@@ -1,1 +1,48 @@
-rvm use ruby-1.9.2
+#!/usr/bin/env bash
+
+# This is an RVM Project .rvmrc file, used to automatically load the ruby
+# development environment upon cd'ing into the directory
+
+# First we specify our desired <ruby>[@<gemset>], the @gemset name is optional,
+# Only full ruby name is supported here, for short names use:
+#     echo "rvm use 1.9.3" > .rvmrc
+environment_id="ruby-1.9.3-p194@log_buddy"
+
+# Uncomment the following lines if you want to verify rvm version per project
+# rvmrc_rvm_version="1.17.2 (stable)" # 1.10.1 seams as a safe start
+# eval "$(echo ${rvm_version}.${rvmrc_rvm_version} | awk -F. '{print "[[ "$1*65536+$2*256+$3" -ge "$4*65536+$5*256+$6" ]]"}' )" || {
+#   echo "This .rvmrc file requires at least RVM ${rvmrc_rvm_version}, aborting loading."
+#   return 1
+# }
+
+# First we attempt to load the desired environment directly from the environment
+# file. This is very fast and efficient compared to running through the entire
+# CLI and selector. If you want feedback on which environment was used then
+# insert the word 'use' after --create as this triggers verbose mode.
+if [[ -d "${rvm_path:-$HOME/.rvm}/environments"
+  && -s "${rvm_path:-$HOME/.rvm}/environments/$environment_id" ]]
+then
+  \. "${rvm_path:-$HOME/.rvm}/environments/$environment_id"
+  [[ -s "${rvm_path:-$HOME/.rvm}/hooks/after_use" ]] &&
+    \. "${rvm_path:-$HOME/.rvm}/hooks/after_use" || true
+else
+  # If the environment file has not yet been created, use the RVM CLI to select.
+  rvm --create  "$environment_id" || {
+    echo "Failed to create RVM environment '${environment_id}'."
+    return 1
+  }
+fi
+
+# If you use bundler, this might be useful to you:
+# if [[ -s Gemfile ]] && {
+#   ! builtin command -v bundle >/dev/null ||
+#   builtin command -v bundle | GREP_OPTIONS= \grep $rvm_path/bin/bundle >/dev/null
+# }
+# then
+#   printf "%b" "The rubygem 'bundler' is not installed. Installing it now.\n"
+#   gem install bundler
+# fi
+# if [[ -s Gemfile ]] && builtin command -v bundle >/dev/null
+# then
+#   bundle install | GREP_OPTIONS= \grep -vE '^Using|Your bundle is complete'
+# fi

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,5 @@
+v0.8.0 Add use_banners option for logging. Wraps output in newlines and a line of '#' symbols
+
 v0.7.0
 * Add use_awesome_print option for logging
 * Fix warning from #split called on nil

--- a/README.markdown
+++ b/README.markdown
@@ -40,9 +40,15 @@ in the block and the result.  Examples:
 
 See examples.rb for live examples you can run.
 
+##OPTIONS
+
 When you occasionally want to disable LogBuddy (but you don't want to have to remove all your debug statements), you can pass the :disabled option into init's options hash:
 
 	LogBuddy.init :disabled => true
+
+If you have problems spotting your debug calls in the mess of other log entries, set use_banners to true. This will insert a newline and a row of 80 '#' symbols above and below your calls to make them much more obvious in long log files.
+
+    LogBuddy.init :use_banners => true
 
 ## REQUIREMENTS
 

--- a/lib/log_buddy.rb
+++ b/lib/log_buddy.rb
@@ -35,6 +35,7 @@ module LogBuddy
     @logger = options[:logger]
     @log_to_stdout = options.has_key?(:log_to_stdout) ? options[:log_to_stdout] : true
     @use_awesome_print = options.has_key?(:use_awesome_print) ? options[:use_awesome_print] : false
+    @use_banners = options.has_key?(:use_banners) ? options[:use_banners] : false
     @disabled = (options[:disabled] == true)
     mixin_to_object
   end
@@ -60,6 +61,10 @@ module LogBuddy
 
     def use_awesome_print?
       @use_awesome_print
+    end
+
+    def use_banners?
+      @use_banners
     end
 
     private

--- a/lib/log_buddy/utils.rb
+++ b/lib/log_buddy/utils.rb
@@ -51,7 +51,7 @@ module LogBuddy
 
     def banner_wrap(str)
       if LogBuddy.use_banners?
-        "\n#{"#"*80}\n\n#{str}\n\n#{"#"*80}\n"
+        "\n#{"#"*80}\n\n#{str}\n#{"#"*80}\n"
       else
         str
       end

--- a/lib/log_buddy/utils.rb
+++ b/lib/log_buddy/utils.rb
@@ -36,7 +36,7 @@ module LogBuddy
 
     def obj_to_string(obj, options = {})
       quote_strings = options.delete(:quote_strings)
-      case obj
+      str = case obj
       when ::String
         quote_strings ? %["#{obj}"] : obj
       when ::Exception
@@ -45,6 +45,15 @@ module LogBuddy
       else
         LogBuddy.use_awesome_print? && obj.respond_to?(:ai) ?
           obj.ai : obj.inspect
+      end
+      banner_wrap(str)
+    end
+
+    def banner_wrap(str)
+      if LogBuddy.use_banners?
+        "\n#{"#"*80}\n\n#{str}\n\n#{"#"*80}\n"
+      else
+        str
       end
     end
   end

--- a/lib/log_buddy/utils.rb
+++ b/lib/log_buddy/utils.rb
@@ -4,6 +4,7 @@ module LogBuddy
     def debug(obj)
       return if @disabled
       str = obj_to_string(obj)
+      str = banner_wrap(str)
       stdout_puts(str) if log_to_stdout?
       logger.debug(str)
     end
@@ -36,7 +37,7 @@ module LogBuddy
 
     def obj_to_string(obj, options = {})
       quote_strings = options.delete(:quote_strings)
-      str = case obj
+      case obj
       when ::String
         quote_strings ? %["#{obj}"] : obj
       when ::Exception
@@ -46,7 +47,6 @@ module LogBuddy
         LogBuddy.use_awesome_print? && obj.respond_to?(:ai) ?
           obj.ai : obj.inspect
       end
-      banner_wrap(str)
     end
 
     def banner_wrap(str)

--- a/lib/log_buddy/version.rb
+++ b/lib/log_buddy/version.rb
@@ -1,7 +1,7 @@
 module LogBuddy
   module Version #:nodoc:
     MAJOR = 0
-    MINOR = 7
+    MINOR = 8
     TINY  = 0
 
     STRING = [MAJOR, MINOR, TINY].join('.')

--- a/spec/log_buddy/log_buddy_spec.rb
+++ b/spec/log_buddy/log_buddy_spec.rb
@@ -36,6 +36,11 @@ describe LogBuddy do
       LogBuddy.init :use_awesome_print => true
       LogBuddy.use_awesome_print?.should == true
     end
+
+    it "can be configured to print large banners to make the debug call easier to spot" do
+      LogBuddy.init :use_banners => true
+      LogBuddy.use_banners?.should == true
+    end
   end
 
 end

--- a/spec/log_buddy/log_spec.rb
+++ b/spec/log_buddy/log_spec.rb
@@ -142,7 +142,6 @@ describe LogBuddy::Mixin, " behavior" do
       end
     end
     
-    
   end
   
   describe "obj_to_string" do
@@ -194,6 +193,25 @@ describe LogBuddy::Mixin, " behavior" do
       LogBuddy.init :log_to_stdout => false
       LogBuddy.expects(:stdout_puts).never
       d { "foo" }
+    end
+  end
+
+  describe "banner_wrap" do
+    include LogBuddy::Utils
+    let(:str) { "Very important debugging code" }
+    before { LogBuddy.stubs(:use_banners?).returns(true) }
+
+    it "should add new lines and a row of '#' symbols" do
+      banner_wrap(str).should match(/\n#+\n/)
+    end
+
+    it "should wrap it if use_banners? is true" do
+      banner_wrap(str).should match(/\n#+\n/)
+    end
+
+    it "should not wrap it if use_banners? is false" do
+      LogBuddy.stubs(:use_banners?).returns(false)
+      banner_wrap(str).should == str
     end
   end
 end


### PR DESCRIPTION
When you set the use_banners option to true, the output from the debug call will print a new line, followed by 80 # symbols, and another newline either side of the output.

Specs are all passing, and readme etc has been updated.
